### PR TITLE
GitHub actions sha pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2 tag
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e #v1 tag
         with:
           node-version: "14.x"
       - run: npm install
       - run: npm test
+


### PR DESCRIPTION
# SHA Pinning

Pin the SHA of the following actions we are using in our `ci.yml` workflow.

- [actions/checkout@v2](https://github.com/actions/checkout/tree/v2) - https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5
- [actions/setup-node@v1](https://github.com/actions/setup-node/tree/v1) - https://github.com/actions/setup-node/commit/f1f314fca9dfce2769ece7d933488f076716723e
